### PR TITLE
STEP 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
 
+	// redisson
+	implementation("org.redisson:redisson-spring-boot-starter:3.23.5")
+	
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,13 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
-
+	  redis:
+	      image: redis:7.2
+	      ports:
+	        - "6379:6379"
+	      volumes:
+	        - ./data/redis/:/data
+	  
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/ecommerce/application/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/coupon/CouponService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
-import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand.CommandCoupon;
+import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponRepository;
 import kr.hhplus.be.ecommerce.domain.coupon.UserCoupon;
 import kr.hhplus.be.ecommerce.domain.coupon.UserCouponRepository;
@@ -53,7 +53,7 @@ public class CouponService {
 	}
 	
 	@Transactional
-	public Boolean createCouponLock(CommandCoupon command) {
+	public Boolean createCouponLock(CouponCommand.Create command) {
 		
 		Coupon coupon = couponRepository.findByIdForUpdate(command.getCouponId())
 										.orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_COUPON));

--- a/src/main/java/kr/hhplus/be/ecommerce/application/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/coupon/CouponService.java
@@ -53,10 +53,8 @@ public class CouponService {
 	}
 	
 	@Transactional
-	public Boolean createCoupon(CommandCoupon command) {
+	public Boolean createCouponLock(CommandCoupon command) {
 		
-//		Coupon coupon = couponRepository.findById(command.getCouponId())
-//										.orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_COUPON));
 		Coupon coupon = couponRepository.findByIdForUpdate(command.getCouponId())
 										.orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_COUPON));
 		coupon.stockCheck();

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
@@ -43,6 +43,15 @@ public class OrderFacade {
 										.stream()
 										.map(c -> redissonClient.getLock("lock:product:" + c.getProductId()))
 										.collect(Collectors.toList());
+		
+		// 회원 조회
+		User userInfo = userService.getUser(orderCommand.getUserId());
+		
+		// 포인트 조회
+		UserPoint userPoint = pointService.searchUserPoint(orderCommand.getUserId());
+		
+		BigDecimal currentUserPoint = userPoint.getUserPoint();
+		
 		try {
 			
 			for (RLock lock : locks) {
@@ -52,23 +61,15 @@ public class OrderFacade {
 				}
 			}
 
-			// 회원 조회
-			User userInfo = userService.getUser(orderCommand.getUserId());
-			
-			// 포인트 조회
-			Optional<UserPoint> userPoint = pointService.searchUserPoint(orderCommand.getUserId());
-			
-			BigDecimal currentUserPoint = userPoint.get().getUserPoint();
-
 			// 상품 주문, 쿠폰 할인 계산
 			List<OrderProduct> orderProducts = orderService.orderProducts(orderCommand);
-
+			
 			// 상품의 총 금액
 			BigDecimal totalPrice = orderService.caculateTotalPrice(orderProducts);
 			
 			// 포인트 차감
 			pointService.usePoint(PointCommand.Use.of(userInfo.getUserId(), totalPrice));
-
+			
 			// 실제 결제 금액
 			BigDecimal paymentAmount = totalPrice;
 			BigDecimal afterUserPoint = currentUserPoint.subtract(totalPrice);
@@ -82,10 +83,11 @@ public class OrderFacade {
 							  , userInfo.getUserId()
 							  , paymentAmount
 							  , afterUserPoint);
-		
+
 		} catch (InterruptedException e) {
 			throw new CustomException(ErrorEnum.FAIL_GET_LOCK);
 		}
+		
 	}
 	
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
@@ -10,7 +10,7 @@ import jakarta.transaction.Transactional;
 import kr.hhplus.be.ecommerce.application.point.PointService;
 import kr.hhplus.be.ecommerce.application.user.UserService;
 import kr.hhplus.be.ecommerce.domain.order.Order;
-import kr.hhplus.be.ecommerce.domain.order.OrderCommand.CommandOrder;
+import kr.hhplus.be.ecommerce.domain.order.OrderCommand;
 import kr.hhplus.be.ecommerce.domain.order.OrderInfo.InfoOrder;
 import kr.hhplus.be.ecommerce.domain.order.OrderProduct;
 import kr.hhplus.be.ecommerce.domain.point.PointCommand;
@@ -29,7 +29,7 @@ public class OrderFacade {
 	private final UserService userService;
 
 	@Transactional
-	public InfoOrder createOrder(CommandOrder commandOrder) {
+	public InfoOrder createOrder(OrderCommand.Create commandOrder) {
 
 		// 회원 조회
 		User userInfo = userService.getUser(commandOrder.getUserId());

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
@@ -3,7 +3,11 @@ package kr.hhplus.be.ecommerce.application.order;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
@@ -16,6 +20,8 @@ import kr.hhplus.be.ecommerce.domain.order.OrderProduct;
 import kr.hhplus.be.ecommerce.domain.point.PointCommand;
 import kr.hhplus.be.ecommerce.domain.point.UserPoint;
 import kr.hhplus.be.ecommerce.domain.user.User;
+import kr.hhplus.be.ecommerce.interfaces.common.CustomException;
+import kr.hhplus.be.ecommerce.interfaces.common.ErrorEnum;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -28,38 +34,58 @@ public class OrderFacade {
 
 	private final UserService userService;
 
+	private final RedissonClient redissonClient;
+
 	@Transactional
-	public InfoOrder createOrder(OrderCommand.Create commandOrder) {
+	public InfoOrder createOrder(OrderCommand.Create orderCommand) {
 
-		// 회원 조회
-		User userInfo = userService.getUser(commandOrder.getUserId());
+		List<RLock> locks = orderCommand.getCriteriaOrderProduct()
+										.stream()
+										.map(c -> redissonClient.getLock("lock:product:" + c.getProductId()))
+										.collect(Collectors.toList());
+		try {
+			
+			for (RLock lock : locks) {
+				boolean available = lock.tryLock(5, 3, TimeUnit.SECONDS);
+				if (!available) {
+					throw new CustomException(ErrorEnum.FAIL_GET_LOCK);
+				}
+			}
+
+			// 회원 조회
+			User userInfo = userService.getUser(orderCommand.getUserId());
+			
+			// 포인트 조회
+			Optional<UserPoint> userPoint = pointService.searchUserPoint(orderCommand.getUserId());
+			
+			BigDecimal currentUserPoint = userPoint.get().getUserPoint();
+
+			// 상품 주문, 쿠폰 할인 계산
+			List<OrderProduct> orderProducts = orderService.orderProducts(orderCommand);
+
+			// 상품의 총 금액
+			BigDecimal totalPrice = orderService.caculateTotalPrice(orderProducts);
+			
+			// 포인트 차감
+			pointService.usePoint(PointCommand.Use.of(userInfo.getUserId(), totalPrice));
+
+			// 실제 결제 금액
+			BigDecimal paymentAmount = totalPrice;
+			BigDecimal afterUserPoint = currentUserPoint.subtract(totalPrice);
+
+			// 주문 저장
+			Order order = orderService.saveOrder(userInfo, totalPrice);
+			orderService.saveOrderProducts(order, orderProducts);
+			orderService.saveOrderHistory(order);
+
+			return InfoOrder.of(order.getOrderId()
+							  , userInfo.getUserId()
+							  , paymentAmount
+							  , afterUserPoint);
 		
-		// 포인트 조회
-		Optional<UserPoint> userPoint = pointService.searchUserPoint(commandOrder.getUserId());
-		
-		BigDecimal currentUserPoint = userPoint.get().getUserPoint();
-		
-		// 상품 주문, 쿠폰 할인 계산
-		List<OrderProduct> orderProducts = orderService.orderProducts(commandOrder);
-
-		// 상품의 총 금액
-		BigDecimal totalPrice = orderService.caculateTotalPrice(orderProducts);
-
-		// 포인트 차감
-		pointService.usePoint(PointCommand.Use.of(userInfo.getUserId(), totalPrice));
-
-		// 실제 결제 금액
-		BigDecimal paymentAmount = totalPrice;
-		BigDecimal afterUserPoint = currentUserPoint.subtract(totalPrice);
-		
-		// 주문 저장
-		Order order = orderService.saveOrder(userInfo, totalPrice);
-		orderService.saveOrderProducts(order, orderProducts);
-		orderService.saveOrderHistory(order);
-
-		return InfoOrder.of(order.getOrderId()
-						  , userInfo.getUserId()
-						  , paymentAmount
-						  , afterUserPoint);
+		} catch (InterruptedException e) {
+			throw new CustomException(ErrorEnum.FAIL_GET_LOCK);
+		}
 	}
+	
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
@@ -44,14 +44,6 @@ public class OrderFacade {
 										.map(c -> redissonClient.getLock("lock:product:" + c.getProductId()))
 										.collect(Collectors.toList());
 		
-		// 회원 조회
-		User userInfo = userService.getUser(orderCommand.getUserId());
-		
-		// 포인트 조회
-		UserPoint userPoint = pointService.searchUserPoint(orderCommand.getUserId());
-		
-		BigDecimal currentUserPoint = userPoint.getUserPoint();
-		
 		try {
 			
 			for (RLock lock : locks) {
@@ -61,6 +53,14 @@ public class OrderFacade {
 				}
 			}
 
+			// 회원 조회
+			User userInfo = userService.getUser(orderCommand.getUserId());
+			
+			// 포인트 조회
+			UserPoint userPoint = pointService.searchUserPoint(orderCommand.getUserId());
+			
+			BigDecimal currentUserPoint = userPoint.getUserPoint();
+			
 			// 상품 주문, 쿠폰 할인 계산
 			List<OrderProduct> orderProducts = orderService.orderProducts(orderCommand);
 			

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderFacade.java
@@ -2,11 +2,11 @@ package kr.hhplus.be.ecommerce.application.order;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
-import kr.hhplus.be.ecommerce.application.coupon.CouponService;
 import kr.hhplus.be.ecommerce.application.point.PointService;
 import kr.hhplus.be.ecommerce.application.user.UserService;
 import kr.hhplus.be.ecommerce.domain.order.Order;
@@ -15,7 +15,6 @@ import kr.hhplus.be.ecommerce.domain.order.OrderInfo.InfoOrder;
 import kr.hhplus.be.ecommerce.domain.order.OrderProduct;
 import kr.hhplus.be.ecommerce.domain.point.PointCommand;
 import kr.hhplus.be.ecommerce.domain.point.UserPoint;
-import kr.hhplus.be.ecommerce.domain.point.UserPointRepository;
 import kr.hhplus.be.ecommerce.domain.user.User;
 import lombok.RequiredArgsConstructor;
 
@@ -36,9 +35,9 @@ public class OrderFacade {
 		User userInfo = userService.getUser(commandOrder.getUserId());
 		
 		// 포인트 조회
-		UserPoint userPoint = pointService.searchUserPoint(commandOrder.getUserId());
+		Optional<UserPoint> userPoint = pointService.searchUserPoint(commandOrder.getUserId());
 		
-		BigDecimal currentUserPoint = userPoint.getUserPoint();
+		BigDecimal currentUserPoint = userPoint.get().getUserPoint();
 		
 		// 상품 주문, 쿠폰 할인 계산
 		List<OrderProduct> orderProducts = orderService.orderProducts(commandOrder);

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderService.java
@@ -40,7 +40,7 @@ public class OrderService {
 	private final CouponService couponService;
 
 	public Product getProduct(Integer productId) {
-		return productRepository.findByProductId(productId)
+		return productRepository.findByProductIdForUpdate(productId)
 								.orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_PRODUCT));
 	}
 
@@ -85,28 +85,19 @@ public class OrderService {
 		
 		for (CriteriaOrderProduct criteria : commandOrder.getCriteriaOrderProduct()) {
 
-			// 쿠폰 조회
 			Coupon coupon = couponService.getCoupon(commandOrder.getCouponId());
 			
-			// 상품 조회
-//			Product product = getProduct(criteria.getProductId());
-			Product product = productRepository.findByProductIdForUpdate(criteria.getProductId())
-											   .orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_PRODUCT));
+			Product product = getProduct(criteria.getProductId());
 			
-			// 사용자 요청 수량과 상품 재고 검증
 			product.validationProductStock(criteria.getQuantity(), product.getStock());
 			
-			// 상품의 총금액(쿠폰x)
 			BigDecimal productTotalPrice = product.getProductPrice()
 												  .multiply(BigDecimal.valueOf(criteria.getQuantity()));
 			
-			// 상품의 총금액(쿠폰o)
 			BigDecimal discountTotalPrice = coupon.calculateDiscount(productTotalPrice);
 			
-			// 상품 재고 차감
 			productRepository.save(product);
 			
-			// 상품 주문
 			orderProducts.add(OrderProduct.builder()
 										  .productId(product.getProductId())
 										  .couponId(coupon.getCouponId())
@@ -114,6 +105,38 @@ public class OrderService {
 										  .totalPrice(discountTotalPrice)
 										  .productPrice(product.getProductPrice())
 										  .build());
+		}
+		
+		return orderProducts;
+		
+	}
+	public List<OrderProduct> orderProductsLock(CommandOrder commandOrder) {
+		
+		List<OrderProduct> orderProducts = new ArrayList<>();
+		
+		for (CriteriaOrderProduct criteria : commandOrder.getCriteriaOrderProduct()) {
+			
+			Coupon coupon = couponService.getCoupon(commandOrder.getCouponId());
+			
+			Product product = productRepository.findByProductIdForUpdate(criteria.getProductId())
+					.orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_PRODUCT));
+			
+			product.validationProductStock(criteria.getQuantity(), product.getStock());
+			
+			BigDecimal productTotalPrice = product.getProductPrice()
+					.multiply(BigDecimal.valueOf(criteria.getQuantity()));
+			
+			BigDecimal discountTotalPrice = coupon.calculateDiscount(productTotalPrice);
+			
+			productRepository.save(product);
+			
+			orderProducts.add(OrderProduct.builder()
+					.productId(product.getProductId())
+					.couponId(coupon.getCouponId())
+					.orderQuantity(criteria.getQuantity())
+					.totalPrice(discountTotalPrice)
+					.productPrice(product.getProductPrice())
+					.build());
 		}
 		
 		return orderProducts;

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderService.java
@@ -11,7 +11,7 @@ import kr.hhplus.be.ecommerce.application.coupon.CouponService;
 import kr.hhplus.be.ecommerce.application.order.OrderCriteria.CriteriaOrderProduct;
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
 import kr.hhplus.be.ecommerce.domain.order.Order;
-import kr.hhplus.be.ecommerce.domain.order.OrderCommand.CommandOrder;
+import kr.hhplus.be.ecommerce.domain.order.OrderCommand;
 import kr.hhplus.be.ecommerce.domain.order.OrderHistory;
 import kr.hhplus.be.ecommerce.domain.order.OrderHistoryRepository;
 import kr.hhplus.be.ecommerce.domain.order.OrderProduct;
@@ -79,7 +79,7 @@ public class OrderService {
 	
 	}
 	
-	public List<OrderProduct> orderProducts(CommandOrder commandOrder) {
+	public List<OrderProduct> orderProducts(OrderCommand.Create commandOrder) {
 		
 		List<OrderProduct> orderProducts = new ArrayList<>();
 		
@@ -110,7 +110,7 @@ public class OrderService {
 		return orderProducts;
 		
 	}
-	public List<OrderProduct> orderProductsLock(CommandOrder commandOrder) {
+	public List<OrderProduct> orderProductsLock(OrderCommand.Create commandOrder) {
 		
 		List<OrderProduct> orderProducts = new ArrayList<>();
 		

--- a/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/order/OrderService.java
@@ -40,7 +40,7 @@ public class OrderService {
 	private final CouponService couponService;
 
 	public Product getProduct(Integer productId) {
-		return productRepository.findByProductIdForUpdate(productId)
+		return productRepository.findByProductId(productId)
 								.orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_PRODUCT));
 	}
 
@@ -54,7 +54,7 @@ public class OrderService {
 						   .cdate(LocalDateTime.now())
 						   .build();
 
-		orderRepository.save(order);
+		orderRepository.saveAndFlush(order);
 		
 		return order;
 	}
@@ -83,69 +83,36 @@ public class OrderService {
 		
 		List<OrderProduct> orderProducts = new ArrayList<>();
 		
-		for (CriteriaOrderProduct criteria : commandOrder.getCriteriaOrderProduct()) {
+		Coupon coupon = couponService.getCoupon(commandOrder.getCouponId());
 
-			Coupon coupon = couponService.getCoupon(commandOrder.getCouponId());
+		for (CriteriaOrderProduct criteria : commandOrder.getCriteriaOrderProduct()) {
 			
-			Product product = getProduct(criteria.getProductId());
+			Product product = productRepository.findByProductId(criteria.getProductId())
+											   .orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_PRODUCT));
+
+			product.validationProductStock(criteria.getQuantity());
 			
-			product.validationProductStock(criteria.getQuantity(), product.getStock());
-			
+			productRepository.saveAndFlush(product);
+
 			BigDecimal productTotalPrice = product.getProductPrice()
 												  .multiply(BigDecimal.valueOf(criteria.getQuantity()));
 			
 			BigDecimal discountTotalPrice = coupon.calculateDiscount(productTotalPrice);
-			
-			productRepository.save(product);
-			
+
 			orderProducts.add(OrderProduct.builder()
 										  .productId(product.getProductId())
 										  .couponId(coupon.getCouponId())
 										  .orderQuantity(criteria.getQuantity())
-										  .totalPrice(discountTotalPrice)
 										  .productPrice(product.getProductPrice())
+										  .totalPrice(discountTotalPrice)
 										  .build());
 		}
-		
 		return orderProducts;
-		
-	}
-	public List<OrderProduct> orderProductsLock(OrderCommand.Create commandOrder) {
-		
-		List<OrderProduct> orderProducts = new ArrayList<>();
-		
-		for (CriteriaOrderProduct criteria : commandOrder.getCriteriaOrderProduct()) {
-			
-			Coupon coupon = couponService.getCoupon(commandOrder.getCouponId());
-			
-			Product product = productRepository.findByProductIdForUpdate(criteria.getProductId())
-					.orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_PRODUCT));
-			
-			product.validationProductStock(criteria.getQuantity(), product.getStock());
-			
-			BigDecimal productTotalPrice = product.getProductPrice()
-					.multiply(BigDecimal.valueOf(criteria.getQuantity()));
-			
-			BigDecimal discountTotalPrice = coupon.calculateDiscount(productTotalPrice);
-			
-			productRepository.save(product);
-			
-			orderProducts.add(OrderProduct.builder()
-					.productId(product.getProductId())
-					.couponId(coupon.getCouponId())
-					.orderQuantity(criteria.getQuantity())
-					.totalPrice(discountTotalPrice)
-					.productPrice(product.getProductPrice())
-					.build());
-		}
-		
-		return orderProducts;
-		
 	}
 	
 	public BigDecimal caculateTotalPrice(List<OrderProduct> products) {
 		return products.stream()
-						.map(OrderProduct::getTotalPrice)
-						.reduce(BigDecimal.ZERO, BigDecimal::add);
+					   .map(OrderProduct::getTotalPrice)
+					   .reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/application/point/PointService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/point/PointService.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.ecommerce.application.point;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
@@ -48,7 +49,6 @@ public class PointService {
 		String userId = pointCommand.getUserId();
 		BigDecimal amount = pointCommand.getUserPoint();
 		
-//		UserPoint userPoint = userPointRepository.findByUserId(userId);
 		UserPoint userPoint = userPointRepository.findByUserIdForUpdate(userId)
 												 .orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_USER));
 
@@ -61,8 +61,8 @@ public class PointService {
 		return true;
 	}
 	
-	public UserPoint searchUserPoint(String userId) {
-		return userPointRepository.findByUserId(userId);
+	public Optional<UserPoint> searchUserPoint(String userId) {
+		return userPointRepository.findByUserIdForUpdate(userId);
 	}
 
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/application/point/PointService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/point/PointService.java
@@ -61,8 +61,8 @@ public class PointService {
 		return true;
 	}
 	
-	public Optional<UserPoint> searchUserPoint(String userId) {
-		return userPointRepository.findByUserIdForUpdate(userId);
+	public UserPoint searchUserPoint(String userId) {
+		return userPointRepository.findByUserId(userId);
 	}
 
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/application/product/ProductService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/product/ProductService.java
@@ -3,7 +3,7 @@ package kr.hhplus.be.ecommerce.application.product;
 import org.springframework.stereotype.Service;
 
 import kr.hhplus.be.ecommerce.domain.product.Product;
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand.CommandProduct;
+import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo.InfoProduct;
 import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
 import kr.hhplus.be.ecommerce.interfaces.common.CustomException;
@@ -17,7 +17,7 @@ public class ProductService {
 	private final ProductRepository productRepository;
 
 	// 상품 조회
-	public InfoProduct getProduct(CommandProduct commandProduct) {
+	public InfoProduct getProduct(ProductCommand.Create commandProduct) {
 		
 		Product product = productRepository.findByProductId(commandProduct.getProductId())
 										   .orElseThrow(() -> new CustomException(ErrorEnum.NOT_FOUND_PRODUCT));

--- a/src/main/java/kr/hhplus/be/ecommerce/application/product/ProductService.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/product/ProductService.java
@@ -1,6 +1,5 @@
 package kr.hhplus.be.ecommerce.application.product;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import kr.hhplus.be.ecommerce.domain.product.Product;
@@ -15,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductService {
 
-	@Autowired
 	private final ProductRepository productRepository;
 
 	// 상품 조회

--- a/src/main/java/kr/hhplus/be/ecommerce/config/redis/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/config/redis/RedissonConfig.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.ecommerce.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	@Bean
+	public RedissonClient redissonClient() {
+		RedissonClient redisson = null;
+		Config config = new Config();
+		config.useSingleServer().setAddress("redis://localhost:6379");
+		redisson = Redisson.create(config);
+		return redisson;
+	}
+	
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/domain/coupon/Coupon.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/domain/coupon/Coupon.java
@@ -1,7 +1,6 @@
 package kr.hhplus.be.ecommerce.domain.coupon;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;

--- a/src/main/java/kr/hhplus/be/ecommerce/domain/coupon/CouponCommand.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/domain/coupon/CouponCommand.java
@@ -5,18 +5,18 @@ import lombok.Getter;
 public class CouponCommand {
 
 	@Getter
-	public static class CommandCoupon {
+	public static class Create {
 		
 		private String userId;
 		private Integer couponId;
 		
-		public CommandCoupon(String userId, Integer couponId) {
+		public Create(String userId, Integer couponId) {
 			this.userId = userId;
 			this.couponId = couponId;
 		}
 		
-		public static CommandCoupon of(String userId, Integer couponId) {
-			return new CommandCoupon(userId, couponId);
+		public static Create of(String userId, Integer couponId) {
+			return new Create(userId, couponId);
 		}
 	}
 	

--- a/src/main/java/kr/hhplus/be/ecommerce/domain/order/OrderCommand.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/domain/order/OrderCommand.java
@@ -8,20 +8,20 @@ import lombok.Getter;
 public class OrderCommand {
 	
 	@Getter
-	public static class CommandOrder {
+	public static class Create {
 		
 		private String userId;
 		private Integer couponId;
 		private List<CriteriaOrderProduct> criteriaOrderProduct;
 		
-		public CommandOrder(String userId, Integer couponId, List<CriteriaOrderProduct> criteriaOrderProduct) {
+		public Create(String userId, Integer couponId, List<CriteriaOrderProduct> criteriaOrderProduct) {
 			this.userId = userId;
 			this.couponId = couponId;
 			this.criteriaOrderProduct = criteriaOrderProduct;
 		}
 		
-		public static CommandOrder of(String userId, Integer couponId, List<CriteriaOrderProduct> criteriaOrderProduct) {
-			return new CommandOrder(userId, couponId, criteriaOrderProduct);
+		public static Create of(String userId, Integer couponId, List<CriteriaOrderProduct> criteriaOrderProduct) {
+			return new Create(userId, couponId, criteriaOrderProduct);
 		}
 		
 	}

--- a/src/main/java/kr/hhplus/be/ecommerce/domain/order/OrderRepository.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/domain/order/OrderRepository.java
@@ -2,4 +2,6 @@ package kr.hhplus.be.ecommerce.domain.order;
 
 public interface OrderRepository{
 	void save(Order orderProduct);
+	
+	void saveAndFlush(Order orderProduct);
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/domain/product/Product.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/domain/product/Product.java
@@ -47,17 +47,14 @@ public class Product {
 	private LocalDateTime udate;
 	
 	// 상품 재고
-	public void validationProductStock(Integer quantity, Integer stock) {
+	public void validationProductStock(Integer quantity) {
 		
-		if(quantity > stock) {
+		if(quantity > this.stock || this.stock <= 0) {
 			throw new CustomException(ErrorEnum.NOT_ENOUGH_PRODUCT);
 		}
 		
 		this.stock -= quantity;
 		
 	}
-	
-	
-	
 	
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/domain/product/ProductCommand.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/domain/product/ProductCommand.java
@@ -8,15 +8,15 @@ import lombok.NoArgsConstructor;
 public class ProductCommand {
 
 	@Getter
-	public static class CommandProduct {
+	public static class Create {
 		private final Integer productId;
 		
-		public CommandProduct(Integer productId) {
+		public Create(Integer productId) {
 			this.productId = productId;
 		}
 		
-		public static CommandProduct of(Integer productId) {
-			return new CommandProduct(productId);
+		public static Create of(Integer productId) {
+			return new Create(productId);
 		}
 	}
 	

--- a/src/main/java/kr/hhplus/be/ecommerce/domain/product/ProductRepository.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/domain/product/ProductRepository.java
@@ -10,4 +10,5 @@ public interface ProductRepository {
 	
 	Optional<Product> findByProductIdForUpdate(Integer productId);
 	
+	void saveAndFlush(Product product);
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/infrastructure/order/OrderProductRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/infrastructure/order/OrderProductRepositoryImpl.java
@@ -1,8 +1,6 @@
 package kr.hhplus.be.ecommerce.infrastructure.order;
 
 import kr.hhplus.be.ecommerce.domain.order.OrderProductRepository;
-import kr.hhplus.be.ecommerce.domain.point.PointHistoryRepository;
-import kr.hhplus.be.ecommerce.infrastructure.point.UserPointJpaRepository;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;

--- a/src/main/java/kr/hhplus/be/ecommerce/infrastructure/order/OrderRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/infrastructure/order/OrderRepositoryImpl.java
@@ -17,4 +17,9 @@ public class OrderRepositoryImpl implements OrderRepository{
 		orderJpaRepository.save(order);
 	}
 	
+	@Override
+	public void saveAndFlush(Order order) {
+		orderJpaRepository.saveAndFlush(order);
+	}
+	
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/infrastructure/product/ProductRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/infrastructure/product/ProductRepositoryImpl.java
@@ -29,4 +29,8 @@ public class ProductRepositoryImpl implements ProductRepository{
  		return productJpaRepository.findByProductIdForUpdate(productId);
  	}
 	
+	@Override
+	public void saveAndFlush(Product product) {
+		productJpaRepository.saveAndFlush(product);
+	}
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/common/ErrorEnum.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/common/ErrorEnum.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorEnum {
 
+	FAIL_GET_LOCK(HttpStatus.BAD_REQUEST, "락을 획득하는데 실패했습니다."),
 	NOT_ENOUGH_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품의 재고가 부족합니다."),
 	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품이 존재하지 않습니다."),
 	CHARGE_POINT_MAX(HttpStatus.BAD_REQUEST, "최대 충전 금액 한도를 초과하셨습니다."),

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/coupon/CouponController.java
@@ -22,7 +22,7 @@ public class CouponController {
 	@PostMapping("/createCoupon")
 	public ApiResponse<?> createCoupon(@RequestBody CoupontRequest couponRequest) {
 		CommandCoupon couponCommand = CommandCoupon.of(couponRequest.getUserId(), couponRequest.getCouponId());
-		couponService.createCoupon(couponCommand);
+		couponService.createCouponLock(couponCommand);
 		return ApiResponse.success();
 	}
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/coupon/CouponController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import kr.hhplus.be.ecommerce.application.coupon.CouponService;
-import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand.CommandCoupon;
+import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand;
 import kr.hhplus.be.ecommerce.interfaces.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -21,7 +21,7 @@ public class CouponController {
 	
 	@PostMapping("/createCoupon")
 	public ApiResponse<?> createCoupon(@RequestBody CoupontRequest couponRequest) {
-		CommandCoupon couponCommand = CommandCoupon.of(couponRequest.getUserId(), couponRequest.getCouponId());
+		CouponCommand.Create couponCommand = CouponCommand.Create.of(couponRequest.getUserId(), couponRequest.getCouponId());
 		couponService.createCouponLock(couponCommand);
 		return ApiResponse.success();
 	}

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/order/OrderController.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/order/OrderController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.hhplus.be.ecommerce.application.order.OrderFacade;
-import kr.hhplus.be.ecommerce.domain.order.OrderCommand.CommandOrder;
+import kr.hhplus.be.ecommerce.domain.order.OrderCommand;
 import kr.hhplus.be.ecommerce.domain.order.OrderInfo.InfoOrder;
 import kr.hhplus.be.ecommerce.interfaces.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +22,9 @@ public class OrderController {
 	
 	@PostMapping("/order")
 	public ApiResponse<?> createOrder(@RequestBody OrderRequest orderRequest) {
-		CommandOrder orderCommand = CommandOrder.of(orderRequest.getUserId()
-												  , orderRequest.getCouponId()
-												  , orderRequest.getCriteriaOrderProduct());
+		OrderCommand.Create orderCommand = OrderCommand.Create.of(orderRequest.getUserId()
+																, orderRequest.getCouponId()
+																, orderRequest.getCriteriaOrderProduct());
 		InfoOrder infoOrder = orderFacade.createOrder(orderCommand);
 		return ApiResponse.success(OrderResponse.from(infoOrder));
 	}

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/order/OrderRequest.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/order/OrderRequest.java
@@ -3,7 +3,7 @@ package kr.hhplus.be.ecommerce.interfaces.order;
 import java.util.List;
 
 import kr.hhplus.be.ecommerce.application.order.OrderCriteria.CriteriaOrderProduct;
-import kr.hhplus.be.ecommerce.domain.order.OrderCommand.CommandOrder;
+import kr.hhplus.be.ecommerce.domain.order.OrderCommand;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,7 +17,7 @@ public class OrderRequest {
 	private Integer couponId;
 	private List<CriteriaOrderProduct> criteriaOrderProduct;
 	
-	public CommandOrder toCommandOrder() {
-		return CommandOrder.of(userId, couponId, criteriaOrderProduct);
+	public OrderCommand.Create toCommandOrder() {
+		return OrderCommand.Create.of(userId, couponId, criteriaOrderProduct);
 	}
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductController.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.hhplus.be.ecommerce.application.product.ProductService;
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand.CommandProduct;
+import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo.InfoProduct;
 import kr.hhplus.be.ecommerce.interfaces.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class ProductController {
 	@GetMapping("/product")
 	public ApiResponse<?> getProduct(ProductRequest productRequest) {
 		
-		CommandProduct productCommand = productRequest.toProductCommand();
+		ProductCommand.Create productCommand = productRequest.toProductCommand();
 		
 		InfoProduct infoProduct = productService.getProduct(productCommand);
 		

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductRequest.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductRequest.java
@@ -1,6 +1,6 @@
 package kr.hhplus.be.ecommerce.interfaces.product;
 
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand.CommandProduct;
+import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,8 +14,8 @@ public class ProductRequest {
 	
 	private Integer productId;
 	
-	public CommandProduct toProductCommand() {
-		return CommandProduct.of(productId);
+	public ProductCommand.Create toProductCommand() {
+		return ProductCommand.Create.of(productId);
 	}
 	
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductRequest.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductRequest.java
@@ -1,9 +1,5 @@
 package kr.hhplus.be.ecommerce.interfaces.product;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import kr.hhplus.be.ecommerce.domain.product.ProductCommand.CommandProduct;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductResponse.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductResponse.java
@@ -1,7 +1,6 @@
 package kr.hhplus.be.ecommerce.interfaces.product;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo.InfoProduct;
 import lombok.AllArgsConstructor;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,8 @@ spring:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponConcurrencyTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
-import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand.CommandCoupon;
+import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponRepository;
 import kr.hhplus.be.ecommerce.domain.user.User;
 import kr.hhplus.be.ecommerce.domain.user.UserRepository;
@@ -75,7 +75,7 @@ public class CouponConcurrencyTest {
 		}
 
 		List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
-		CommandCoupon commandCoupon = CommandCoupon.of(userId, couponId);
+		CouponCommand.Create commandCoupon = CouponCommand.Create.of(userId, couponId);
 		for (String uid : userIds) {
 			executorService.submit(() -> {
 				try {

--- a/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponConcurrencyTest.java
@@ -79,7 +79,7 @@ public class CouponConcurrencyTest {
 		for (String uid : userIds) {
 			executorService.submit(() -> {
 				try {
-					couponService.createCoupon(commandCoupon);
+					couponService.createCouponLock(commandCoupon);
 				} catch (Throwable t) {
 					errors.add(t);
 				} finally {

--- a/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponIntegrationTest.java
@@ -2,7 +2,6 @@ package kr.hhplus.be.ecommerce.application.coupon;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
 
@@ -16,11 +15,8 @@ import jakarta.transaction.Transactional;
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand.CommandCoupon;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponRepository;
-import kr.hhplus.be.ecommerce.domain.coupon.UserCouponRepository;
 import kr.hhplus.be.ecommerce.domain.user.User;
 import kr.hhplus.be.ecommerce.domain.user.UserRepository;
-import kr.hhplus.be.ecommerce.interfaces.common.CustomException;
-import kr.hhplus.be.ecommerce.interfaces.common.ErrorEnum;
 
 @SpringBootTest
 @Transactional
@@ -34,9 +30,6 @@ public class CouponIntegrationTest {
 
 	@Autowired
 	private UserRepository userRepository;
-
-	@Autowired
-	private UserCouponRepository userCouponRepository;
 
 	private String userId;
 	private Integer couponId;

--- a/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponIntegrationTest.java
@@ -68,7 +68,7 @@ public class CouponIntegrationTest {
 
 		CommandCoupon commandCoupon = new CommandCoupon(userId, couponId);
 		
-		boolean result = couponService.createCoupon(commandCoupon);
+		boolean result = couponService.createCouponLock(commandCoupon);
 
 		assertThat(result).isTrue();
 	}

--- a/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponIntegrationTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import jakarta.transaction.Transactional;
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
-import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand.CommandCoupon;
+import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponRepository;
 import kr.hhplus.be.ecommerce.domain.user.User;
 import kr.hhplus.be.ecommerce.domain.user.UserRepository;
@@ -59,7 +59,7 @@ public class CouponIntegrationTest {
 	@DisplayName("쿠폰 발급 성공")
 	void createCouponSuccess() {
 
-		CommandCoupon commandCoupon = new CommandCoupon(userId, couponId);
+		CouponCommand.Create commandCoupon = new CouponCommand.Create(userId, couponId);
 		
 		boolean result = couponService.createCouponLock(commandCoupon);
 

--- a/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponServiceTest.java
@@ -17,7 +17,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
-import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand.CommandCoupon;
+import kr.hhplus.be.ecommerce.domain.coupon.CouponCommand;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponRepository;
 import kr.hhplus.be.ecommerce.domain.coupon.UserCouponRepository;
 import kr.hhplus.be.ecommerce.interfaces.common.CustomException;
@@ -39,7 +39,7 @@ public class CouponServiceTest {
 	@DisplayName("쿠폰 발급 성공")
 	void createCouponSuccess() {
 
-		CommandCoupon command = new CommandCoupon("hanghae", 1);
+		CouponCommand.Create command = new CouponCommand.Create("hanghae", 1);
 		Coupon coupon = Mockito.mock(Coupon.class);
 
 		when(couponRepository.findByIdForUpdate(1)).thenReturn(Optional.of(coupon));
@@ -54,7 +54,7 @@ public class CouponServiceTest {
 	@DisplayName("쿠폰이 존재하지 않을 경우 예외 발생")
 	void createCouponFail() {
 
-		CommandCoupon command = new CommandCoupon("hanghae", 999);
+		CouponCommand.Create command = new CouponCommand.Create("hanghae", 999);
 		when(couponRepository.findByIdForUpdate(999)).thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> couponService.createCouponLock(command)).isInstanceOf(CustomException.class)
@@ -65,7 +65,7 @@ public class CouponServiceTest {
 	@DisplayName("쿠폰 재고가 부족할 경우 예외 발생")
 	void createCouponStockFail() {
 		
-		CommandCoupon command = new CommandCoupon("user123", 1);
+		CouponCommand.Create command = new CouponCommand.Create("user123", 1);
 		Coupon coupon = mock(Coupon.class);
 
 		when(couponRepository.findByIdForUpdate(1)).thenReturn(Optional.of(coupon));

--- a/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/coupon/CouponServiceTest.java
@@ -42,9 +42,9 @@ public class CouponServiceTest {
 		CommandCoupon command = new CommandCoupon("hanghae", 1);
 		Coupon coupon = Mockito.mock(Coupon.class);
 
-		when(couponRepository.findById(1)).thenReturn(Optional.of(coupon));
+		when(couponRepository.findByIdForUpdate(1)).thenReturn(Optional.of(coupon));
 
-		Boolean result = couponService.createCoupon(command);
+		Boolean result = couponService.createCouponLock(command);
 
 		assertThat(result).isTrue();
 
@@ -55,9 +55,9 @@ public class CouponServiceTest {
 	void createCouponFail() {
 
 		CommandCoupon command = new CommandCoupon("hanghae", 999);
-		when(couponRepository.findById(999)).thenReturn(Optional.empty());
+		when(couponRepository.findByIdForUpdate(999)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> couponService.createCoupon(command)).isInstanceOf(CustomException.class)
+		assertThatThrownBy(() -> couponService.createCouponLock(command)).isInstanceOf(CustomException.class)
 				.hasMessageContaining(ErrorEnum.NOT_FOUND_COUPON.getMessage());
 	}
 
@@ -68,10 +68,10 @@ public class CouponServiceTest {
 		CommandCoupon command = new CommandCoupon("user123", 1);
 		Coupon coupon = mock(Coupon.class);
 
-		when(couponRepository.findById(1)).thenReturn(Optional.of(coupon));
+		when(couponRepository.findByIdForUpdate(1)).thenReturn(Optional.of(coupon));
 		doThrow(new CustomException(ErrorEnum.COUPON_STOCK_EMPTY)).when(coupon).stockCheck();
 
-		assertThatThrownBy(() -> couponService.createCoupon(command)).isInstanceOf(CustomException.class)
+		assertThatThrownBy(() -> couponService.createCouponLock(command)).isInstanceOf(CustomException.class)
 																	 .hasMessageContaining(ErrorEnum.COUPON_STOCK_EMPTY.getMessage());
 	}
 

--- a/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderConcurrencyTest.java
@@ -124,7 +124,6 @@ public class OrderConcurrencyTest {
 
 		latch.await();
 
-		// then
 		assertThat(errors).hasSize(1);
 		assertThat(errors.get(0).getMessage()).contains(ErrorEnum.NOT_ENOUGH_PRODUCT.getMessage());
 	}

--- a/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderConcurrencyTest.java
@@ -21,7 +21,7 @@ import kr.hhplus.be.ecommerce.application.order.OrderCriteria.CriteriaOrderProdu
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponEnum;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponRepository;
-import kr.hhplus.be.ecommerce.domain.order.OrderCommand.CommandOrder;
+import kr.hhplus.be.ecommerce.domain.order.OrderCommand;
 import kr.hhplus.be.ecommerce.domain.point.UserPoint;
 import kr.hhplus.be.ecommerce.domain.point.UserPointRepository;
 import kr.hhplus.be.ecommerce.domain.product.Product;
@@ -96,7 +96,7 @@ public class OrderConcurrencyTest {
 
 		Runnable task1 = () -> {
 			try {
-				CommandOrder command = CommandOrder.of("hanghae_basic", couponId,
+				OrderCommand.Create command = OrderCommand.Create.of("hanghae_basic", couponId,
 						List.of(new CriteriaOrderProduct(productId, 1)));
 				orderFacade.createOrder(command);
 			} catch (Throwable t) {
@@ -108,7 +108,7 @@ public class OrderConcurrencyTest {
 
 		Runnable task2 = () -> {
 			try {
-				CommandOrder command = CommandOrder.of("hanghae_advanced", couponId,
+				OrderCommand.Create command = OrderCommand.Create.of("hanghae_advanced", couponId,
 						List.of(new CriteriaOrderProduct(productId, 1)));
 				orderFacade.createOrder(command);
 			} catch (Throwable t) {

--- a/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderConcurrencyTest.java
@@ -28,6 +28,7 @@ import kr.hhplus.be.ecommerce.domain.product.Product;
 import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
 import kr.hhplus.be.ecommerce.domain.user.User;
 import kr.hhplus.be.ecommerce.domain.user.UserRepository;
+import kr.hhplus.be.ecommerce.interfaces.common.ErrorEnum;
 
 @SpringBootTest
 public class OrderConcurrencyTest {
@@ -125,6 +126,6 @@ public class OrderConcurrencyTest {
 
 		// then
 		assertThat(errors).hasSize(1);
-		assertThat(errors.get(0).getMessage()).contains("재고 부족");
+		assertThat(errors.get(0).getMessage()).contains(ErrorEnum.NOT_ENOUGH_PRODUCT.getMessage());
 	}
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceIntegrationTest.java
@@ -24,7 +24,7 @@ import kr.hhplus.be.ecommerce.domain.order.OrderInfo.InfoOrder;
 import kr.hhplus.be.ecommerce.domain.point.UserPoint;
 import kr.hhplus.be.ecommerce.domain.point.UserPointRepository;
 import kr.hhplus.be.ecommerce.domain.product.Product;
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand.CommandProduct;
+import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo.InfoProduct;
 import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
 import kr.hhplus.be.ecommerce.domain.user.User;
@@ -101,7 +101,7 @@ public class OrderServiceIntegrationTest {
 	@DisplayName("상품 조회 성공 (상품이 존재할 경우)")
 	void successGetProduct() {
 		
-		CommandProduct command = new CommandProduct(productId);
+		ProductCommand.Create command = new ProductCommand.Create(productId);
 
 		InfoProduct result = productService.getProduct(command);
 
@@ -115,7 +115,7 @@ public class OrderServiceIntegrationTest {
 	@DisplayName("상품 조회 실패 (상품이 없을 경우)")
 	void failGetProduct_notFound() {
 		
-		CommandProduct command = new CommandProduct(99);
+		ProductCommand.Create command = new ProductCommand.Create(99);
 
 		assertThatThrownBy(() -> productService.getProduct(command)).isInstanceOf(CustomException.class)
 																	.hasMessageContaining(ErrorEnum.NOT_FOUND_PRODUCT.getMessage());

--- a/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceIntegrationTest.java
@@ -19,7 +19,7 @@ import kr.hhplus.be.ecommerce.application.product.ProductService;
 import kr.hhplus.be.ecommerce.domain.coupon.Coupon;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponEnum;
 import kr.hhplus.be.ecommerce.domain.coupon.CouponRepository;
-import kr.hhplus.be.ecommerce.domain.order.OrderCommand.CommandOrder;
+import kr.hhplus.be.ecommerce.domain.order.OrderCommand;
 import kr.hhplus.be.ecommerce.domain.order.OrderInfo.InfoOrder;
 import kr.hhplus.be.ecommerce.domain.point.UserPoint;
 import kr.hhplus.be.ecommerce.domain.point.UserPointRepository;
@@ -126,7 +126,7 @@ public class OrderServiceIntegrationTest {
 	@DisplayName("상품 주문 쿠폰 사용")
 	void createOrderCoupon() {
 
-		CommandOrder command = CommandOrder.of(userId, couponId, List.of(new CriteriaOrderProduct(productId, 1)));
+		OrderCommand.Create command = OrderCommand.Create.of(userId, couponId, List.of(new CriteriaOrderProduct(productId, 1)));
 
 		InfoOrder result = orderFacade.createOrder(command);
 

--- a/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceTest.java
@@ -51,7 +51,7 @@ public class OrderServiceTest {
 	@Mock
 	private UserRepository userRepository;
 	
-	@Mock
+	@InjectMocks
 	private UserService userService;
 
 	@Test
@@ -64,9 +64,9 @@ public class OrderServiceTest {
 								 .stock(10)
 								 .build();
 
-		when(productRepository.findByProductId(1)).thenReturn(Optional.of(product));
+		when(productRepository.findByProductIdForUpdate(product.getProductId())).thenReturn(Optional.of(product));
 
-		Product result = orderService.getProduct(1);
+		Product result = orderService.getProduct(product.getProductId());
 
 		assertThat(result).isNotNull();
 		assertThat(result.getProductName()).isEqualTo("상품");
@@ -75,12 +75,18 @@ public class OrderServiceTest {
 	@Test
 	@DisplayName("사용자 조회 성공")
 	void validateUser_success() {
-		User user = new User("hanghae", "서울시 광진구", LocalDateTime.now());
-		when(userRepository.findByUserId("hanghae")).thenReturn(Optional.of(user));
+		
+		User user = User.builder()
+						.userId("hanghae")
+						.address("서울시 광진구")
+						.cdate(LocalDateTime.now())
+						.build();
+		
+		when(userRepository.findByUserId(user.getUserId())).thenReturn(Optional.of(user));
 
-		User result = userService.getUser("hanghae");
+		User result = userService.getUser(user.getUserId());
 
-		assertThat(result.getAddress()).isEqualTo("서울시 광진구");
+		assertThat(result.getAddress()).isEqualTo(user.getAddress());
 	}
 
 	@Test

--- a/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/order/OrderServiceTest.java
@@ -64,7 +64,7 @@ public class OrderServiceTest {
 								 .stock(10)
 								 .build();
 
-		when(productRepository.findByProductIdForUpdate(product.getProductId())).thenReturn(Optional.of(product));
+		when(productRepository.findByProductId(product.getProductId())).thenReturn(Optional.of(product));
 
 		Product result = orderService.getProduct(product.getProductId());
 

--- a/src/test/java/kr/hhplus/be/ecommerce/application/point/PointServiceTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/point/PointServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -25,12 +24,10 @@ import kr.hhplus.be.ecommerce.domain.point.PointHistoryRepository;
 import kr.hhplus.be.ecommerce.domain.point.PointInfo;
 import kr.hhplus.be.ecommerce.domain.point.UserPoint;
 import kr.hhplus.be.ecommerce.domain.point.UserPointRepository;
-import kr.hhplus.be.ecommerce.domain.user.User;
 import kr.hhplus.be.ecommerce.domain.user.UserRepository;
 import kr.hhplus.be.ecommerce.interfaces.common.CustomException;
 import kr.hhplus.be.ecommerce.interfaces.common.ErrorEnum;
 import kr.hhplus.be.ecommerce.interfaces.point.PointRequest;
-import kr.hhplus.be.ecommerce.interfaces.point.PointResponse;
 
 @ExtendWith(MockitoExtension.class)
 public class PointServiceTest {
@@ -51,7 +48,6 @@ public class PointServiceTest {
 	@DisplayName("포인트 충전 성공")
 	void successCharge() {
 
-		// given
 		String userId = "hanghae";
 
 		BigDecimal currentPoint = new BigDecimal("5000");
@@ -64,10 +60,8 @@ public class PointServiceTest {
 
 		when(userPointRepository.findByUserId(userId)).thenReturn(userPoint);
 
-		// when
 		PointInfo.Point resultPoint = pointService.chargeUserPoint(pointCommand);
 
-		// then
 		assertThat(resultPoint.getUserPoint()).isEqualByComparingTo(totalPoint);
 
 		verify(userPointRepository).save(userPoint);

--- a/src/test/java/kr/hhplus/be/ecommerce/application/point/PointServiceTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/point/PointServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -106,7 +107,7 @@ public class PointServiceTest {
 		PointRequest pointRequest = new PointRequest(userId, currentPoint);
 		PointCommand.Use useCommand = pointRequest.toUseCommand();
 
-		when(userPointRepository.findByUserId(userId)).thenReturn(userPoint);
+		when(userPointRepository.findByUserIdForUpdate(userId)).thenReturn(Optional.of(userPoint));
 
 		boolean result = pointService.usePoint(useCommand);
 
@@ -122,17 +123,17 @@ public class PointServiceTest {
 	void failUserPoint() {
 
 		String userId = "hanghae";
+
 		BigDecimal currentPoint = new BigDecimal("500");
 		BigDecimal amountToUse = new BigDecimal("1000");
 
 		UserPoint userPoint = new UserPoint(userId, currentPoint);
 		PointCommand.Use useCommand = PointCommand.Use.of(userId, amountToUse);
 
-		when(userPointRepository.findByUserId(userId)).thenReturn(userPoint);
+		when(userPointRepository.findByUserIdForUpdate(userId)).thenReturn(Optional.of(userPoint));
 
-		assertThatThrownBy(() -> pointService.usePoint(useCommand))
-											 .isInstanceOf(CustomException.class)
-											 .hasMessageContaining(ErrorEnum.NOT_ENOUGH_POINT.getMessage());
+		assertThatThrownBy(() -> pointService.usePoint(useCommand)).isInstanceOf(CustomException.class)
+																   .hasMessageContaining(ErrorEnum.NOT_ENOUGH_POINT.getMessage());
 	}
 
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductServiceIntegrationTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import jakarta.transaction.Transactional;
 import kr.hhplus.be.ecommerce.domain.product.Product;
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand.CommandProduct;
+import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo.InfoProduct;
 import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
 import kr.hhplus.be.ecommerce.interfaces.common.CustomException;
@@ -50,7 +50,7 @@ public class ProductServiceIntegrationTest {
 	@DisplayName("상품 조회 성공 (상품이 존재할 경우)")
 	void successGetProduct() {
 		
-		CommandProduct command = new CommandProduct(productId);
+		ProductCommand.Create command = new ProductCommand.Create(productId);
 
 		InfoProduct result = productService.getProduct(command);
 
@@ -64,7 +64,7 @@ public class ProductServiceIntegrationTest {
 	@DisplayName("상품 조회 실패 (상품이 없을 경우)")
 	void failGetProduct_notFound() {
 		
-		CommandProduct command = new CommandProduct(99);
+		ProductCommand.Create command = new ProductCommand.Create(99);
 
 		assertThatThrownBy(() -> productService.getProduct(command)).isInstanceOf(CustomException.class)
 																	.hasMessageContaining(ErrorEnum.NOT_FOUND_PRODUCT.getMessage());

--- a/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductServiceIntegrationTest.java
@@ -30,6 +30,8 @@ public class ProductServiceIntegrationTest {
 	@Autowired
 	private ProductService productService;
 	
+	private Integer productId;
+	
 	@BeforeEach
 	void setUp() {
 		Product product = Product.builder()
@@ -41,18 +43,19 @@ public class ProductServiceIntegrationTest {
 								 .build();
 
 		productRepository.save(product);
+		productId = product.getProductId();
 	}
 
 	@Test
 	@DisplayName("상품 조회 성공 (상품이 존재할 경우)")
 	void successGetProduct() {
 		
-		CommandProduct command = new CommandProduct(1);
+		CommandProduct command = new CommandProduct(productId);
 
 		InfoProduct result = productService.getProduct(command);
 
 		assertThat(result).isNotNull();
-		assertThat(result.getProductId()).isEqualTo(1);
+		assertThat(result.getProductId()).isEqualTo(productId);
 		assertThat(result.getProductName()).isEqualTo("상품1");
 		
 	}

--- a/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductServiceTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import kr.hhplus.be.ecommerce.domain.product.Product;
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand.CommandProduct;
+import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo.InfoProduct;
 import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
 
@@ -45,7 +45,7 @@ public class ProductServiceTest {
 	void successGetProduct() {
 		
 		Integer productId = 1;
-		CommandProduct command = new CommandProduct(productId);
+		ProductCommand.Create command = new ProductCommand.Create(productId);
 
 		Product product = Product.builder()
 								 .productId(productId)


### PR DESCRIPTION
## PR 설명
- 분산락 구현 [`56cbf40`](https://github.com/khs2973/hhplus-ecommerce/commit/56cbf402a72d117988f212fd09f79bf9cc90305d)

## 리뷰 포인트
- 현재 Redis 기반으로 동시성 테스트를 구현하던 중, `@Transactional`이 `Facade` 계층에 선언되어 있는 구조에서 내부 도메인 데이터를 조기에 반영해야 하는 상황이 생겨 `saveAndFlush()`를 사용하게 되었습니다.
이처럼 트랜잭션 도중에 `saveAndFlush()`를 호출하여 강제 반영하는 방식이 일반적으로 권장되는 접근인지 혹은 더 바람직한 처리 방식이 있는지 궁금합니다.


### **이번주 KPT 회고**

### Keep
- 트랜잭션 경계와 동시성 처리에 대한 이해도를 높이기 위해 `@Transactional`의 적용 범위와 역할을 정리하고 적용함

### Problem
- `@Transactional` 범위 내에서 중간 저장이 필요한 상황이 발생해 `saveAndFlush()`를 사용하게 되었는데, 이 방식이 과연 적절한지에 대한 확신 부족
- Redis 캐시 적용을 시도했으나 Redis의 개념 부족으로 적용하지 못한

### Try
- `flush()`나 `saveAndFlush()` 없이도 도메인 이벤트나 트랜잭션 내 이벤트 처리로 해결할 수 있는 구조 리팩토링 실험
- Redis 캐시 적용과 캐시 미스 대응, 스탬피드 방지 전략도 적용해볼것